### PR TITLE
make zlib match node

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,4 +34,4 @@ exports.tty							= require.resolve('tty-browserify');
 exports.url							= require.resolve('url/');
 exports.util						= require.resolve('util/util.js');
 exports.vm							= require.resolve('vm-browserify');
-exports.zlib						= require.resolve('zlib-browserify');
+exports.zlib						= require.resolve('browserify-zlib');

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
 		"vm-browserify": "0.0.4",
 		"crypto-browserify": "~2.1.0",
 		"http-browserify": "~1.3.2",
-		"zlib-browserify": "0.0.3",
+		"browserify-zlib": "~0.1.4",
 		"https-browserify": "0.0.0",
 		"tty-browserify": "0.0.0",
 		"constants-browserify": "0.0.1",


### PR DESCRIPTION
Browserify recently [switched](https://github.com/substack/node-browserify/pull/721) to a new [zlib module](https://github.com/devongovett/browserify-zlib) that I wrote with full Node API and binary compatibility.  I thought I'd share the love to webpack as well. :wink: 
