### PR TITLE
pin crypto-browserify to 3.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
 	"dependencies": {
 		"console-browserify": "^1.1.0",
 		"vm-browserify": "0.0.4",
-		"crypto-browserify": "^3.0.0",
+		"crypto-browserify": "3.3.0",
 		"http-browserify": "^1.3.2",
 		"browserify-zlib": "~0.1.4",
 		"https-browserify": "0.0.0",


### PR DESCRIPTION
A recent commit in https://github.com/indutny/brorand/blame/5f14e3492bcd089d21b0e7ced9ba5236a4fd6328/index.js#L52 messes up webpack builds; pinning crypto-browserify fixes the problem for now until either a) all module parsing is wrapped in an IIFE, or b) the illegal return statement is removed in https://github.com/indutny/brorand/.

See: https://github.com/webpack/webpack/issues/67.
