### PR TITLE
Added very basic mocks for `net` and `dns`

### DIFF
--- a/mock/dns.js
+++ b/mock/dns.js
@@ -1,0 +1,15 @@
+exports.lookup = exports.resolve4 =
+exports.resolve6 = exports.resolveCname =
+exports.resolveMx = exports.resolveNs =
+exports.resolveTxt = exports.resolveSrv =
+exports.resolveNaptr = exports.reverse =
+exports.resolve =
+function () {
+  if (!arguments.length) return;
+
+  var callback = arguments[arguments.length - 1];
+  if (callback && typeof callback === 'function') {
+    callback(null, '0.0.0.0')
+  }
+}
+

--- a/mock/net.js
+++ b/mock/net.js
@@ -1,0 +1,10 @@
+exports.createServer =
+exports.createConnection =
+exports.connect =
+function () {};
+
+exports.isIP =
+exports.isIPv4 =
+exports.isIPv6 =
+function () { return true };
+


### PR DESCRIPTION
One of the modules I was trying to use on the client side had some light dependencies on node's `net` and `dns`. This PR includes very basic mocks for both of those core libraries. I tried to structure things similarly to other mocks. Let me know if anything isn't up to standards.