### PR TITLE
update process to 0.11

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "https-browserify": "0.0.0",
     "os-browserify": "~0.1.2",
     "path-browserify": "0.0.0",
-    "process": "~0.10.0",
+    "process": "^0.11.0",
     "punycode": "^1.2.4",
     "querystring-es3": "~0.2.0",
     "readable-stream": "^1.1.13",


### PR DESCRIPTION
`process@0.11` has a very important [fix](https://github.com/defunctzombie/node-process/pull/38) that fixes the queue being completely clogged when an error happens so can we bump it :(

@sokra 