### PR TITLE
Add repository field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,5 +35,20 @@
     }
   ],
   "homepage": "http://github.com/webpack/node-libs-browser",
-  "main": "index.js"
+  "main": "index.js",
+  "files": [
+    "index.js",
+    "mock/"
+  ],
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/webpack/node-libs-browser.git"
+  },
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/webpack/node-libs-browser/issues"
+  }
 }


### PR DESCRIPTION
This warning was driving me crazy :laughing: 

![image](https://cloud.githubusercontent.com/assets/1404810/7556145/603e8084-f765-11e4-94f9-433d378938ce.png)

I just ran `npm init`, and set the `license` to the same as main webpack, as this repo has no `LICENSE` file.

Also added `files`-field. Only diff is `.gitattributes` and the `.npmignore` automatically added by npm.