### PR TITLE
Uprev crypto-browserify to latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "buffer": "^3.0.3",
     "console-browserify": "^1.1.0",
     "constants-browserify": "0.0.1",
-    "crypto-browserify": "~3.2.6",
+    "crypto-browserify": "~3.9.14",
     "domain-browser": "^1.1.1",
     "events": "^1.0.0",
     "http-browserify": "^1.3.2",


### PR DESCRIPTION
The current referenced version of crypto-browserify does not have support for new stream methods of hash functions, e.g. 
```
var h = crypto.createHash('sha1'); 
h.write('a');
h.end('b');
h.read();
```

As a result, using webpack to pack the `node-rsa` package, for example, causes an error to occur as `node-rsa` is using the new stream support.

Please uprev the referenced version of `crypto-browserify`, as per this PR.