### PR TITLE
Bump crypto-browserify to ~3.8.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "buffer": "^3.0.3",
     "console-browserify": "^1.1.0",
     "constants-browserify": "0.0.1",
-    "crypto-browserify": "~3.2.6",
+    "crypto-browserify": "~3.8.0",
     "domain-browser": "^1.1.1",
     "events": "^1.0.0",
     "http-browserify": "^1.3.2",


### PR DESCRIPTION
Let's update `crypto-browserify` to the latest version that doesn't break https://github.com/webpack/node-libs-browser/issues/19