### PR TITLE
Upgrade crypto-browserify dependency to latest 3.10.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "buffer": "^3.0.3",
     "console-browserify": "^1.1.0",
     "constants-browserify": "0.0.1",
-    "crypto-browserify": "~3.2.6",
+    "crypto-browserify": "~3.10.0",
     "domain-browser": "^1.1.1",
     "events": "^1.0.0",
     "http-browserify": "^1.3.2",


### PR DESCRIPTION
Fixes #34. Obsoletes #28.

It would be great if this could be merged, and we could get node-libs-browser 0.5.4 integrated into a new webpack release.