### PR TITLE
v0.5.4 buffer version update

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-libs-browser",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "author": "Tobias Koppers @sokra",
   "description": "The node core libs for in browser usage.",
   "repository": {
@@ -10,7 +10,7 @@
   "dependencies": {
     "assert": "^1.1.1",
     "browserify-zlib": "~0.1.4",
-    "buffer": "^3.0.3",
+    "buffer": "^4.9.0",
     "console-browserify": "^1.1.0",
     "constants-browserify": "0.0.1",
     "crypto-browserify": "~3.2.6",


### PR DESCRIPTION
https://github.com/webpack/webpack/pull/2854
https://github.com/webpack/webpack/issues/2678
https://github.com/mqttjs/MQTT.js/issues/445

updating buffer dependency and create a new node-libs-browser version

@sokra There are merge conflict, because of the tag v1.0.0 already delivered can you take a look? can you tag it please?

thanks