### PR TITLE
Bumped crypto-browserify version to 3.11.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-libs-browser",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "author": "Tobias Koppers @sokra",
   "description": "The node core libs for in browser usage.",
   "repository": {
@@ -13,7 +13,7 @@
     "buffer": "^4.9.0",
     "console-browserify": "^1.1.0",
     "constants-browserify": "0.0.1",
-    "crypto-browserify": "~3.2.6",
+    "crypto-browserify": "^3.11.0",
     "domain-browser": "^1.1.1",
     "events": "^1.0.0",
     "http-browserify": "^1.3.2",


### PR DESCRIPTION
Fixes https://github.com/webpack/node-libs-browser/issues/40

We are having this problem using Webpack:
```
Node.js (win32; U; rv:v6.9.0) ERROR
  _crypto is not defined
  at webpack:///./~/crypto-browserify/rng.js?:5
```
Which is solved by this commit in `crypto-browserify@3.4.0`: https://github.com/crypto-browserify/crypto-browserify/commit/30d96df5f6cdbe8ecdb4e7ef584a218ba3e302e2

We are not ready to migrate to Webpack2 yet, so this is the next best solution. I've bumped the `crypto-browserify` dependency to `3.11.0`, and changed the `node-libs-browser` version to `0.6.1` so it will be picked up as a dependency in Webpack1.