### PR TITLE
Upgrade zlib

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,15 +36,15 @@ Some modules have mocks in the `mock` directory. These are replacements with min
 | stream | [substack/stream-browserify](https://github.com/substack/stream-browserify) | --- |
 | string_decoder | [rvagg/string_decoder](https://github.com/rvagg/string_decoder) | --- |
 | sys | [defunctzombie/node-util](https://github.com/defunctzombie/node-util) | --- |
-| timers | [jryans/timers-browserify](https://github.com/jryans/timers-browserify) | --- | 
+| timers | [jryans/timers-browserify](https://github.com/jryans/timers-browserify) | --- |
 | tls | --- | [tls.js](https://github.com/webpack/node-libs-browser/blob/master/mock/tls.js) |
 | tty | [substack/tty-browserify](https://github.com/substack/tty-browserify) | [tty.js](https://github.com/webpack/node-libs-browser/blob/master/mock/tty.js) |
 | url | [defunctzombie/node-url](https://github.com/defunctzombie/node-url) | --- |
 | util | [defunctzombie/node-util](https://github.com/defunctzombie/node-util) | --- |
 | vm | [substack/vm-browserify](https://github.com/substack/vm-browserify) | --- |
-| zlib | [devongovett/browserify-zlib](https://github.com/devongovett/browserify-zlib) | --- |
+| zlib | [ipfs/browserify-zlib-next](https://github.com/ipfs/browserify-zlib-next) | --- |
 
-## Outdated versions 
+## Outdated versions
 
 ### `buffer`
 

--- a/index.js
+++ b/index.js
@@ -35,4 +35,4 @@ exports.tty							= require.resolve('tty-browserify');
 exports.url							= require.resolve('url/');
 exports.util						= require.resolve('util/util.js');
 exports.vm							= require.resolve('vm-browserify');
-exports.zlib						= require.resolve('browserify-zlib');
+exports.zlib						= require.resolve('browserify-zlib-next');

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "assert": "^1.1.1",
-    "browserify-zlib": "^0.1.4",
+    "browserify-zlib-next": "^1.0.0",
     "buffer": "^4.3.0",
     "console-browserify": "^1.1.0",
     "constants-browserify": "^1.0.0",


### PR DESCRIPTION
Details and background can be found in #51. This upgrades zlib to include fixes and additions up to node 6. 

Closes #51