### PR TITLE
Updated string_decoder to v1.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "readable-stream": "^2.0.5",
     "stream-browserify": "^2.0.1",
     "stream-http": "^2.3.1",
-    "string_decoder": "^0.10.25",
+    "string_decoder": "^1.0.0",
     "timers-browserify": "^2.0.2",
     "tty-browserify": "0.0.0",
     "url": "^0.11.0",


### PR DESCRIPTION
As titled. It includes the most recent pull from node v7.8.0.