### PR TITLE
update https-browserify

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "crypto-browserify": "^3.11.0",
     "domain-browser": "^1.1.1",
     "events": "^1.0.0",
-    "https-browserify": "0.0.1",
+    "https-browserify": "^1.0.0",
     "os-browserify": "^0.2.0",
     "path-browserify": "0.0.0",
     "process": "^0.11.0",


### PR DESCRIPTION
Update `https-browserify` to 1.0.0
Critical bug fixed: https://github.com/substack/https-browserify/issues/6 