### PR TITLE
Bump `os-browserify`

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "domain-browser": "^1.1.1",
     "events": "^1.0.0",
     "https-browserify": "0.0.1",
-    "os-browserify": "^0.2.0",
+    "os-browserify": "^0.3.0",
     "path-browserify": "0.0.0",
     "process": "^0.11.0",
     "punycode": "^1.2.4",


### PR DESCRIPTION
This adds support for `os.homedir()`.