### PR TITLE
Update ferros/buffer to version 5

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "assert": "^1.1.1",
     "browserify-zlib": "^0.1.4",
-    "buffer": "^4.3.0",
+    "buffer": "^5.0.7",
     "console-browserify": "^1.1.0",
     "constants-browserify": "^1.0.0",
     "crypto-browserify": "^3.11.0",


### PR DESCRIPTION
Hi,

is it possible to update ferros/buffer to version 5? Problem is that [versions 4.X](https://github.com/feross/buffer/blob/v4.9.1/index.js#L43) refers to global
```
Buffer.TYPED_ARRAY_SUPPORT = global.TYPED_ARRAY_SUPPORT !== undefined
  ? global.TYPED_ARRAY_SUPPORT
  : typedArraySupport()
```
which leads to #60 and #31 

[this patch](https://github.com/feross/buffer/commit/8746070093390396e497be53e900240c51c2ba49) has fixed this problem and [version 5.X](https://github.com/feross/buffer/blob/v5.0.7/index.js) works just fine. 

We used shrinkwrap to work it around, but would be better to have updated version of the node-libs-browser (npm-shrinkwrap.json):

```
{
  "dependencies": {
    "webpack": {
      "version": "3.3.0",
      "dependencies": {
        "node-libs-browser": {
          "version": "2.0.0",
          "dependencies": {
            "buffer": {
              "version": "5.0.7"
            }
          }
        }
      }
    }
  }
}
```

Thanks in advance!