### PR TITLE
update querystring-es3 version

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "path-browserify": "0.0.0",
     "process": "^0.11.0",
     "punycode": "^1.2.4",
-    "querystring-es3": "^0.2.0",
+    "querystring-es3": "^1.0.0",
     "readable-stream": "^2.0.5",
     "stream-browserify": "^2.0.1",
     "stream-http": "^2.3.1",


### PR DESCRIPTION
`querystring-es3` package has been updated to make its API up to date with Node 6. It may be important for some people using newer API methods.

For example, there is an issue in `aws4` package, that uses `querystring.escape`: https://github.com/mhart/aws4/issues/46 Because of that, the package is not useful in Webpack, but works well with Browserify.

Updating dependency would solve this as well as other similar issues