### PR TITLE
Update events to v3

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "constants-browserify": "^1.0.0",
     "crypto-browserify": "^3.11.0",
     "domain-browser": "^1.1.1",
-    "events": "^1.0.0",
+    "events": "^2.0.0",
     "https-browserify": "^1.0.0",
     "os-browserify": "^0.3.0",
     "path-browserify": "0.0.0",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "constants-browserify": "^1.0.0",
     "crypto-browserify": "^3.11.0",
     "domain-browser": "^1.1.1",
-    "events": "^2.0.0",
+    "events": "^3.0.0",
     "https-browserify": "^1.0.0",
     "os-browserify": "^0.3.0",
     "path-browserify": "0.0.0",


### PR DESCRIPTION
Matches the Node 10 API. v1 matched Node 4, and some new methods have
since been introduced (notably `prepend[Once]Listener`). v2 matched
Node 8, but since then Node 10 has added `.off()`.

The major bump to v2 was because:

 - There is a breaking change in the `listeners()` method regarding
   `once()` listeners https://github.com/nodejs/node/pull/6881
   I think it's super unlikely to affect anyone, but there you go.
 - The gzipped size almost doubled from 1.1KB to 2.1KB. It'll shrink a
   bit in future releases because some patches have since landed in
   Node that remove some code, but it'll still be bigger than it was
   because of the new methods.

The major bump to v3 was because:

 - Support for pre-ES5 environments was dropped (eg. IE8)
 - The new `.off()` method is a common name that could cause collisions
   with userland implmentations if users modified the EventEmitter
   prototype. This again is unlikely to hurt anyone, because even if they
   did define their own `.off()` on the EventEmitter prototype, it would
   99% certainly be doing the same thing.

Deets:
https://github.com/Gozala/events/releases/tag/v2.0.0
https://github.com/Gozala/events/releases/tag/v3.0.0