### PR TITLE
upgrade vm-browserify to v1.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "tty-browserify": "0.0.0",
     "url": "^0.11.0",
     "util": "^0.10.3",
-    "vm-browserify": "0.0.4"
+    "vm-browserify": "^1.1.0"
   },
   "homepage": "http://github.com/webpack/node-libs-browser",
   "main": "index.js",


### PR DESCRIPTION
It is a backwards compatible change.

It avoid the obsolete, unlicensed 'indexof@0.0.1' npm package.