### PR TITLE
Accept arguments to process.nextTick(fn, ...args), just like Node.js's process.nextTick(callback [, ...args]).

### DIFF
--- a/mock/process.js
+++ b/mock/process.js
@@ -1,5 +1,9 @@
 exports.nextTick = function nextTick(fn) {
-	setTimeout(fn, 0);
+    var args = Array.prototype.slice.call(arguments);
+    args.shift();
+    setTimeout(function () {
+        fn.apply(null, args);
+    }, 0);
 };
 
 exports.platform = exports.arch = 


### PR DESCRIPTION
Node.js's [process.nextTick(callback [, ...args])](https://nodejs.org/api/process.html#process_process_nexttick_callback_args) implementation accepts callback arguments.

This PR adds argument support to match.