### PR TITLE
Add `toString` method to process.js

### DIFF
--- a/mock/process.js
+++ b/mock/process.js
@@ -28,3 +28,4 @@ exports.umask = exports.dlopen =
 exports.uptime = exports.memoryUsage = 
 exports.uvCounters = function() {};
 exports.features = {};
+exports.toString = function () { return "[object process]" };


### PR DESCRIPTION
In Node.js:
```js
process + "" // = "[object process]"
```

This patch just brings that behaviour over. I've seen this check in the wild (namely [here](https://github.com/zotero/zotero/blob/b99ee1f0308f6f12bbc1bc46e2a8d478e347c7ed/chrome/content/zotero/xpcom/utilities.js#L2028)).

---

I've also made a PR at defunctzombie/node-process#87. I don't know if this is appropriate for the mock object here.