### PR TITLE
Update path-browserify

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -310,11 +310,6 @@
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.8.tgz",
       "integrity": "sha1-vjPUCsEO8ZJnAfbwii2G+/0a0+Q="
     },
-    "indexof": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz",
-      "integrity": "sha1-gtwzbSMrkGIXnQWrMpOmYFn9Q10="
-    },
     "inherits": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
@@ -387,9 +382,9 @@
       }
     },
     "path-browserify": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.1.tgz",
-      "integrity": "sha512-BapA40NHICOS+USX9SN4tyhq+A2RrN/Ws5F0Z5aMHDp98Fl86lX8Oti8B7uN93L4Ifv4fHOEA+pQw87gmMO/lQ=="
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
+      "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g=="
     },
     "pbkdf2": {
       "version": "3.0.14",
@@ -588,14 +583,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
-    },
-    "vm-browserify": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.4.tgz",
-      "integrity": "sha1-XX6kW7755Kb/ZflUOOCofDV9WnM=",
-      "requires": {
-        "indexof": "0.0.1"
-      }
     },
     "xtend": {
       "version": "4.0.1",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "events": "^3.0.0",
     "https-browserify": "^1.0.0",
     "os-browserify": "^0.3.0",
-    "path-browserify": "0.0.1",
+    "path-browserify": "1.0.1",
     "process": "^0.11.10",
     "punycode": "^1.2.4",
     "querystring-es3": "^0.2.0",


### PR DESCRIPTION
I recently stumbled upon an [issue](https://github.com/AssemblyScript/assemblyscript/issues/1398) with `path.relative` as provided by [path-browserify](https://github.com/browserify/path-browserify). According to https://github.com/browserify/path-browserify/issues/21#issuecomment-661098844, the problem is fixed in v1.0.0 of the package, so this PR updates the dependency to `path-browserify@1.0.1` to mitigate the problem.

As a side note: I noticed that this package is deprecated. Is it expected that its dependencies still become bundled when using webpack 4.43.0? Just curious :)